### PR TITLE
Modernize supported versions; release 2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django-version: ["4.2", "5.0", "5.1"]
-        python-version: ["3.10", "3.11", "3.12"]
+        django-version: ["4.2", "5.0", "5.1", "5.2", "6.0"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        exclude:
+          - django-version: "4.2"
+            python-version: "3.13"
+          - django-version: "4.2"
+            python-version: "3.14"
+          - django-version: "5.0"
+            python-version: "3.13"
+          - django-version: "5.0"
+            python-version: "3.14"
+          - django-version: "5.1"
+            python-version: "3.14"
+          - django-version: "6.0"
+            python-version: "3.10"
+          - django-version: "6.0"
+            python-version: "3.11"
     services:
       redis:
         image: redis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,15 +14,18 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Communications :: Email",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -32,7 +35,8 @@ description = "Provides Django email integration for RQ (Redis Queue)"
 license = { "file" = "LICENSE" }
 name = "django-rq-email-backend"
 readme = "README.rst"
-version = "2.0.0"
+requires-python = ">=3.10"
+version = "2.1.0"
 
 [project.urls]
 Homepage = "https://github.com/knyghty/django-rq-email-backend"
@@ -49,7 +53,7 @@ exclude = ["/tests", "requirements.txt", "runtests.py"]
 packages = ["django_rq_email_backend"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 ignore = ["ISC001", "S105"]


### PR DESCRIPTION
Aligns the packaging metadata with reality and extends support:

- Drops the Python 3.9 classifier — upstream `django-rq` no longer publishes a working 3.9 release, so it can't be tested or supported.
- Adds `requires-python = ">=3.10"` (pip keeps serving 2.0.0 to older Pythons).
- Adds Django 5.2/6.0 and Python 3.13/3.14 to the classifiers and CI matrix.
- Bumps the version to 2.1.0, ready to release once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)